### PR TITLE
Revamp of fetchSoundcloudVersion.

### DIFF
--- a/index.js
+++ b/index.js
@@ -231,7 +231,7 @@ module.exports.fetchSoundcloudKey = async (force=false) => {
 
 /**
  * Fetches soundcloud api version
- * @returns {Promise<string|null>}
+ * @returns {Promise<number|null>}
  */
 module.exports.fetchSoundcloudVersion = async () => {
     return await Util.apiVersion();

--- a/src/Util.js
+++ b/src/Util.js
@@ -184,9 +184,8 @@ class Util {
     static apiVersion() {
         return new Promise(async resolve => {
             try {
-                const html = await Util.parseHTML("https://soundcloud.com");
-                const matches = /__sc_version\s*=\s*"(?<apiVersion>[^"]+)/.exec(html);
-                return resolve(matches.groups.apiVersion);
+                const html = await Util.parseHTML("https://soundcloud.com/version.txt");
+                return resolve(parseInt(html));
             } catch(e) {
                 resolve(null);
             }


### PR DESCRIPTION
Uses the "/version.txt" route and has "fetchSoundcloudVersion" return a number promise instead of a string promise.