### PR TITLE
Add promise rejection handling

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -73,57 +73,61 @@ class Client {
      */
     getSongInfo(url, options = { fetchEmbed: false, fetchComments: false, fetchStreamURL: false, requestOptions: {} }) {
         return new Promise(async (resolve, reject) => {
-            if (typeof url !== "string") return reject(new TypeError(`URL type must be a string, received "${typeof url}"!`));
-            if (!Util.validateURL(url, "track")) return reject(new TypeError("Invalid song url!"));
-            const raw = await Util.parseHTML(url, options.requestOptions || {});
-            if (!raw) return reject(new Error("Couldn't parse html!"));
-            const $ = Util.loadHTML(raw);
+            try {
+                if (typeof url !== "string") return reject(new TypeError(`URL type must be a string, received "${typeof url}"!`));
+                if (!Util.validateURL(url, "track")) return reject(new TypeError("Invalid song url!"));
+                const raw = await Util.parseHTML(url, options.requestOptions || {});
+                if (!raw) return reject(new Error("Couldn't parse html!"));
+                const $ = Util.loadHTML(raw);
 
-            const duration = raw.split('<meta itemprop="duration" content="') && raw.split('<meta itemprop="duration" content="')[1] && raw.split('<meta itemprop="duration" content="')[1].split('" />')[0];
-            const name = raw.split("<h1 itemprop=\"name\">") && raw.split("<h1 itemprop=\"name\">")[1].split("by <a")[1] && raw.split("<h1 itemprop=\"name\">")[1].split("by <a")[1].split(">")[1] && raw.split("<h1 itemprop=\"name\">")[1].split("by <a")[1].split(">")[1].split("</a>")[0].replace("</a", "")
-            const trackURLBase = raw.split('},{"url":"')[1];
-            let trackURL = null;
-            if (trackURLBase) trackURL = trackURLBase.split('","')[0];
-            const commentSection = raw.split("<section class=\"comments\">") && raw.split("<section class=\"comments\">")[1] ? raw.split("<section class=\"comments\">")[1].split("</section>")[0] : null
+                const duration = raw.split('<meta itemprop="duration" content="') && raw.split('<meta itemprop="duration" content="')[1] && raw.split('<meta itemprop="duration" content="')[1].split('" />')[0];
+                const name = raw.split("<h1 itemprop=\"name\">") && raw.split("<h1 itemprop=\"name\">")[1].split("by <a")[1] && raw.split("<h1 itemprop=\"name\">")[1].split("by <a")[1].split(">")[1] && raw.split("<h1 itemprop=\"name\">")[1].split("by <a")[1].split(">")[1].split("</a>")[0].replace("</a", "")
+                const trackURLBase = raw.split('},{"url":"')[1];
+                let trackURL = null;
+                if (trackURLBase) trackURL = trackURLBase.split('","')[0];
+                const commentSection = raw.split("<section class=\"comments\">") && raw.split("<section class=\"comments\">")[1] ? raw.split("<section class=\"comments\">")[1].split("</section>")[0] : null
 
-            const obj = {
-                id: $("meta[property=\"al:ios:url\"]").attr("content").split(":").pop(),
-                title: $("meta[property=\"og:title\"]").attr("content"),
-                description: $("meta[property=\"og:description\"]").attr("content"),
-                thumbnail: $("meta[property=\"og:image\"]").attr("content"),
-                url: $("link[rel=\"canonical\"]").attr("href"),
-                duration: duration ? Util.parseDuration(duration) : 0,
-                playCount: $("meta[property=\"soundcloud:play_count\"]").attr("content"),
-                commentsCount: $("meta[property=\"soundcloud:comments_count\"]").attr("content"),
-                likes: $("meta[property=\"soundcloud:like_count\"]").attr("content"),
-                genre: raw.split(",\"genre\":\"")[1] && raw.split(",\"genre\":\"")[1].split("\",\"")[0].replace(/\\u0026/g, "&"),
-                author: {
-                    name: name || null,
-                    username: $("meta[property=\"soundcloud:user\"]").attr("content").replace("https://soundcloud.com/", ""),
-                    url: $("meta[property=\"soundcloud:user\"]").attr("content"),
-                    avatarURL: raw.split('"avatar_url":"') && raw.split('"avatar_url":"')[raw.split('"avatar_url":"').length - 1].split('"')[0] || null,
-                    urn: parseInt(Constants.USER_URN_PATTERN.exec(raw).groups.urn) || null,
-                    verified: !raw.includes("\",\"verified\":false,\"visuals\""),
-                    followers: parseInt(raw.split(",\"followers_count\":") && raw.split(",\"followers_count\":")[1].split(",")[0]) || 0,
-                    following: parseInt(raw.split(",\"followings_count\":") && raw.split(",\"followings_count\":")[1].split(",")[0]) || 0,
-                },
-                publishedAt: new Date(raw.split("<time pubdate>")[1] && raw.split("<time pubdate>")[1].split("</time>")[0]) || null,
-                embedURL: $("link[type=\"text/json+oembed\"]").attr("href"),
-                embed: !!options.fetchEmbed ? await this.getEmbed($("link[type=\"text/json+oembed\"]").attr("href")) : null,
-                track: {
-                    hls: trackURL ? trackURL.replace("/progressive", "/hls") : null,
-                    progressive: trackURL || null
-                },
-                trackURL: trackURL || null,
-                comments: !!options.fetchComments && !!commentSection ? Util.parseComments(commentSection) : []
-            };
+                const obj = {
+                    id: $("meta[property=\"al:ios:url\"]").attr("content").split(":").pop(),
+                    title: $("meta[property=\"og:title\"]").attr("content"),
+                    description: $("meta[property=\"og:description\"]").attr("content"),
+                    thumbnail: $("meta[property=\"og:image\"]").attr("content"),
+                    url: $("link[rel=\"canonical\"]").attr("href"),
+                    duration: duration ? Util.parseDuration(duration) : 0,
+                    playCount: $("meta[property=\"soundcloud:play_count\"]").attr("content"),
+                    commentsCount: $("meta[property=\"soundcloud:comments_count\"]").attr("content"),
+                    likes: $("meta[property=\"soundcloud:like_count\"]").attr("content"),
+                    genre: raw.split(",\"genre\":\"")[1] && raw.split(",\"genre\":\"")[1].split("\",\"")[0].replace(/\\u0026/g, "&"),
+                    author: {
+                        name: name || null,
+                        username: $("meta[property=\"soundcloud:user\"]").attr("content").replace("https://soundcloud.com/", ""),
+                        url: $("meta[property=\"soundcloud:user\"]").attr("content"),
+                        avatarURL: raw.split('"avatar_url":"') && raw.split('"avatar_url":"')[raw.split('"avatar_url":"').length - 1].split('"')[0] || null,
+                        urn: parseInt(Constants.USER_URN_PATTERN.exec(raw).groups.urn) || null,
+                        verified: !raw.includes("\",\"verified\":false,\"visuals\""),
+                        followers: parseInt(raw.split(",\"followers_count\":") && raw.split(",\"followers_count\":")[1].split(",")[0]) || 0,
+                        following: parseInt(raw.split(",\"followings_count\":") && raw.split(",\"followings_count\":")[1].split(",")[0]) || 0,
+                    },
+                    publishedAt: new Date(raw.split("<time pubdate>")[1] && raw.split("<time pubdate>")[1].split("</time>")[0]) || null,
+                    embedURL: $("link[type=\"text/json+oembed\"]").attr("href"),
+                    embed: !!options.fetchEmbed ? await this.getEmbed($("link[type=\"text/json+oembed\"]").attr("href")) : null,
+                    track: {
+                        hls: trackURL ? trackURL.replace("/progressive", "/hls") : null,
+                        progressive: trackURL || null
+                    },
+                    trackURL: trackURL || null,
+                    comments: !!options.fetchComments && !!commentSection ? Util.parseComments(commentSection) : []
+                };
 
-            if (!!options.fetchStreamURL) {
-                const url = await this.fetchStreamURL(obj.trackURL);
-                obj.streamURL = url || "";
-            } else obj.streamURL = "";
+                if (!!options.fetchStreamURL) {
+                    const url = await this.fetchStreamURL(obj.trackURL);
+                    obj.streamURL = url || "";
+                } else obj.streamURL = "";
 
-            return resolve(new Song(obj));
+                return resolve(new Song(obj));
+            } catch (e) {
+                return reject(e);
+            }
         });
     }
 
@@ -161,75 +165,79 @@ class Client {
      */
     getPlaylist(url, options = { fetchEmbed: false }) {
         return new Promise(async (resolve, reject) => {
-            if (!url || typeof url !== "string") return reject(new Error(`URL must be a string, received "${typeof url}"!`));
-            if (!Util.validateURL(url, "playlist")) return reject(new TypeError("Invalid url!"));
-
-            const raw = await Util.parseHTML(url);
-            if (!raw) return reject(new Error("Couldn't parse html!"));
-            const $ = Util.loadHTML(raw);
-
-            let section;
             try {
-                section = JSON.parse(`[{"id": ${raw.split(`{}})},[{"id":`)[1].split(");")[0]}`);
-            } catch(e) {
-                throw new Error(`Could not parse playlist:\n${e.message}`);
+                if (!url || typeof url !== "string") return reject(new Error(`URL must be a string, received "${typeof url}"!`));
+                if (!Util.validateURL(url, "playlist")) return reject(new TypeError("Invalid url!"));
+
+                const raw = await Util.parseHTML(url);
+                if (!raw) return reject(new Error("Couldn't parse html!"));
+                const $ = Util.loadHTML(raw);
+
+                let section;
+                try {
+                    section = JSON.parse(`[{"id": ${raw.split(`{}})},[{"id":`)[1].split(");")[0]}`);
+                } catch(e) {
+                    throw new Error(`Could not parse playlist:\n${e.message}`);
+                }
+
+                const data = Util.last(section).data[0];
+                data.tracks = data.tracks.filter(data => data.id && data.title);
+                const getMedia = (m, a) => m.media.transcodings.find(x => x.format.protocol === a);
+
+                const info = {
+                    id: data.id,
+                    title: data.title,
+                    url: data.permalink_url,
+                    description: $('meta[property="og:description"]').attr("content"),
+                    thumbnail: data.artwork_url,
+                    author: {
+                        profile: data.user.permalink_url,
+                        username: data.user.permalink,
+                        name: data.user.username,
+                        urn: data.user.id,
+                        verified: Boolean(data.user.verified)
+                    },
+                    embedURL: $('link[type="text/json+oembed"]').attr("href"),
+                    embed: options && !!options.fetchEmbed ? await this.getEmbed($('link[type="text/json+oembed"]').attr("href")) : null,
+                    genre: `${raw.split(',"genre":"')[1].split('"')[0]}`.replace(/\\u0026/g, "&"),
+                    trackCount: data.track_count || 0,
+                    tracks: data.tracks.map(m => new Song({
+                            id: m.id,
+                            title: m.title,
+                            description: m.description,
+                            thumbnail: m.artwork_url,
+                            url: m.permalink_url,
+                            duration: m.full_duration || m.duration,
+                            playCount: m.playback_count,
+                            commentsCount: m.comment_count,
+                            likes: m.likes_count,
+                            genre: m.genre,
+                            author: {
+                                name: m.user.full_name,
+                                username: m.user.permalink,
+                                url: m.user.permalink_url,
+                                avatarURL: m.user.avatar_url,
+                                urn: m.user.id,
+                                verified: !!m.user.verified,
+                                followers: 0,
+                                following: 0
+                            },
+                            publishedAt: new Date(m.created_at) || null,
+                            embedURL: null,
+                            embed: null,
+                            track: {
+                                hls: getMedia(m, "hls") ? getMedia(m, "hls").url : null,
+                                progressive: getMedia(m, "progressive").url
+                            },
+                            trackURL: getMedia(m, "progressive").url,
+                            comments: []
+                        }))
+                };
+
+                return resolve(info);
+            } catch (e) {
+                return reject(e);
             }
-
-            const data = Util.last(section).data[0];
-            data.tracks = data.tracks.filter(data => data.id && data.title);
-            const getMedia = (m, a) => m.media.transcodings.find(x => x.format.protocol === a);
-
-            const info = {
-                id: data.id,
-                title: data.title,
-                url: data.permalink_url,
-                description: $('meta[property="og:description"]').attr("content"),
-                thumbnail: data.artwork_url,
-                author: {
-                    profile: data.user.permalink_url,
-                    username: data.user.permalink,
-                    name: data.user.username,
-                    urn: data.user.id,
-                    verified: Boolean(data.user.verified)
-                },
-                embedURL: $('link[type="text/json+oembed"]').attr("href"),
-                embed: options && !!options.fetchEmbed ? await this.getEmbed($('link[type="text/json+oembed"]').attr("href")) : null,
-                genre: `${raw.split(',"genre":"')[1].split('"')[0]}`.replace(/\\u0026/g, "&"),
-                trackCount: data.track_count || 0,
-                tracks: data.tracks.map(m => new Song({
-                        id: m.id,
-                        title: m.title,
-                        description: m.description,
-                        thumbnail: m.artwork_url,
-                        url: m.permalink_url,
-                        duration: m.full_duration || m.duration,
-                        playCount: m.playback_count,
-                        commentsCount: m.comment_count,
-                        likes: m.likes_count,
-                        genre: m.genre,
-                        author: {
-                            name: m.user.full_name,
-                            username: m.user.permalink,
-                            url: m.user.permalink_url,
-                            avatarURL: m.user.avatar_url,
-                            urn: m.user.id,
-                            verified: !!m.user.verified,
-                            followers: 0,
-                            following: 0
-                        },
-                        publishedAt: new Date(m.created_at) || null,
-                        embedURL: null,
-                        embed: null,
-                        track: {
-                            hls: getMedia(m, "hls") ? getMedia(m, "hls").url : null,
-                            progressive: getMedia(m, "progressive").url
-                        },
-                        trackURL: getMedia(m, "progressive").url,
-                        comments: []
-                    }))
-            };
-
-            resolve(info);
         });
     }
 
@@ -251,63 +259,67 @@ class Client {
      */
     search(query, type = "all") {
         return new Promise(async (resolve, reject) => {
-            if (!query || typeof query !== "string") return reject(new Error(`Expected search query to be a string, received "${typeof query}"!`));
-            const validType = ["all", "artist", "playlist", "track"];
-            if (!validType.includes(type)) throw new Error(`Search type expected to be one of ${validType.map(m => `"${m}"`).join(", ")} but received "${type}"!`);
+            try {
+                if (!query || typeof query !== "string") return reject(new Error(`Expected search query to be a string, received "${typeof query}"!`));
+                const validType = ["all", "artist", "playlist", "track"];
+                if (!validType.includes(type)) throw new Error(`Search type expected to be one of ${validType.map(m => `"${m}"`).join(", ")} but received "${type}"!`);
 
-            let searchPath;
+                let searchPath;
 
-            switch(type) {
-                case "artist":
-                    searchPath = "/search/people?q=";
-                    break;
-                case "playlist":
-                    searchPath = "/search/sets?q=";
-                    break;
-                case "track":
-                    searchPath = "/search/sounds?q=";
-                    break;
-                default:
-                    searchPath = "/search?q=";
-            }
-
-            const raw = await Util.parseHTML(`${Constants.SOUNDCLOUD_BASE_URL}${searchPath}${encodeURIComponent(query)}`);
-            const html = raw.split("<noscript><ul>")[1].split("</ul>")[1].split("</noscript>")[0];            
-            const $ = Util.loadHTML(html);
-            const arr = [];
-            if ($("li").length < 1) return resolve(arr);
-
-            $("li").each((i) => {
-                const ref = $("a").eq(i).attr("href");
-                const c = ref.split("/").filter(x => !!x);
-                let t;
-
-                switch(c.length) {
-                    case 2:
-                        t = "track";
+                switch(type) {
+                    case "artist":
+                        searchPath = "/search/people?q=";
                         break;
-                    case 1:
-                        t = "artist";
+                    case "playlist":
+                        searchPath = "/search/sets?q=";
                         break;
-                    case 3:
-                        if (c.includes("sets")) t = "playlist";
-                        else t = "unknown";
+                    case "track":
+                        searchPath = "/search/sounds?q=";
                         break;
                     default:
-                        t = "unknown";
+                        searchPath = "/search?q=";
                 }
 
-                arr.push({
-                    index: i,
-                    artist: c[0] || null,
-                    url: `${Constants.SOUNDCLOUD_BASE_URL}${ref}`,
-                    itemName: c.length === 1 ? null : c.pop(),
-                    name: $("a").eq(i).text(),
-                    type: t
-                });
-            });
+                const raw = await Util.parseHTML(`${Constants.SOUNDCLOUD_BASE_URL}${searchPath}${encodeURIComponent(query)}`);
+                const html = raw.split("<noscript><ul>")[1].split("</ul>")[1].split("</noscript>")[0];            
+                const $ = Util.loadHTML(html);
+                const arr = [];
+                if ($("li").length < 1) return resolve(arr);
 
-            return resolve(arr);
+                $("li").each((i) => {
+                    const ref = $("a").eq(i).attr("href");
+                    const c = ref.split("/").filter(x => !!x);
+                    let t;
+
+                    switch(c.length) {
+                        case 2:
+                            t = "track";
+                            break;
+                        case 1:
+                            t = "artist";
+                            break;
+                        case 3:
+                            if (c.includes("sets")) t = "playlist";
+                            else t = "unknown";
+                            break;
+                        default:
+                            t = "unknown";
+                    }
+
+                    arr.push({
+                        index: i,
+                        artist: c[0] || null,
+                        url: `${Constants.SOUNDCLOUD_BASE_URL}${ref}`,
+                        itemName: c.length === 1 ? null : c.pop(),
+                        name: $("a").eq(i).text(),
+                        type: t
+                    });
+                });
+
+                return resolve(arr);
+            } catch (e) {
+                return reject(e);
+            }
         });
     }
 
@@ -357,76 +369,80 @@ class Client {
      */
     getUser(username) {
         return new Promise(async (resolve, reject) => {
-            if (!username || typeof username !== "string") reject(new Error(`Expected username to be a string, received "${typeof username}"!`));
-            const BASE_URL = Constants.SOUNDCLOUD_BASE_URL;
-            if (!username.includes(BASE_URL)) username = `${BASE_URL}/${username}`;
-            if (!Util.validateURL(username, "artist")) reject(new Error("Invalid artist url"));
-            
-            const html = await Util.parseHTML(username);
-            const URNSearch = /soundcloud:\/\/users:(?<urn>\d+)/.exec(html);
-            if (!URNSearch || !URNSearch.groups.urn) return reject(new Error("User not found!"));
-            const tracksSection = html.split("<section>")[1].split("</section>")[0];
+            try {
+                if (!username || typeof username !== "string") reject(new Error(`Expected username to be a string, received "${typeof username}"!`));
+                const BASE_URL = Constants.SOUNDCLOUD_BASE_URL;
+                if (!username.includes(BASE_URL)) username = `${BASE_URL}/${username}`;
+                if (!Util.validateURL(username, "artist")) reject(new Error("Invalid artist url"));
 
-            const $ = Util.loadHTML(tracksSection);
-            let banner = null;
-            if (html.includes(',"visual_url":"')) banner = html.split(',"visual_url":"')[1].split('"')[0];
-            const name = html.split(`:${URNSearch.groups.urn}","username":"`)[1].split('"')[0];
-            const profile = Util.last(html.split('"permalink_url":"')).split('"')[0];
+                const html = await Util.parseHTML(username);
+                const URNSearch = /soundcloud:\/\/users:(?<urn>\d+)/.exec(html);
+                if (!URNSearch || !URNSearch.groups.urn) return reject(new Error("User not found!"));
+                const tracksSection = html.split("<section>")[1].split("</section>")[0];
 
-            const likesSource = await Util.parseHTML(`${username}/likes`);
-            const lhtml = likesSource.split("<section>")[1].split("</section>")[0];
-            const $$ = Util.loadHTML(lhtml);
-            let likes = [];
-            let songs = [];
+                const $ = Util.loadHTML(tracksSection);
+                let banner = null;
+                if (html.includes(',"visual_url":"')) banner = html.split(',"visual_url":"')[1].split('"')[0];
+                const name = html.split(`:${URNSearch.groups.urn}","username":"`)[1].split('"')[0];
+                const profile = Util.last(html.split('"permalink_url":"')).split('"')[0];
 
-            $("article").each(i => {
-                const url = $('a[itemprop="url"]').eq(i);
+                const likesSource = await Util.parseHTML(`${username}/likes`);
+                const lhtml = likesSource.split("<section>")[1].split("</section>")[0];
+                const $$ = Util.loadHTML(lhtml);
+                let likes = [];
+                let songs = [];
 
-                songs.push({
-                    title: url.text(),
-                    url: `${Constants.SOUNDCLOUD_BASE_URL}${url.attr("href")}`,
-                    publishedAt: new Date($("time").eq(i).text()),
-                    genre: $('meta[itemprop="genre"]').eq(i).attr("content"),
-                    author: profile.split("/").pop(),
-                    duration: Util.parseDuration($('meta[itemprop="duration"]').eq(i).attr("content"))
+                $("article").each(i => {
+                    const url = $('a[itemprop="url"]').eq(i);
+
+                    songs.push({
+                        title: url.text(),
+                        url: `${Constants.SOUNDCLOUD_BASE_URL}${url.attr("href")}`,
+                        publishedAt: new Date($("time").eq(i).text()),
+                        genre: $('meta[itemprop="genre"]').eq(i).attr("content"),
+                        author: profile.split("/").pop(),
+                        duration: Util.parseDuration($('meta[itemprop="duration"]').eq(i).attr("content"))
+                    });
                 });
-            });
 
-            $$("article").each(i => {
-                const url = $('a[itemprop="url"]').eq(i);
-                const LastA = $('a').eq(1);
+                $$("article").each(i => {
+                    const url = $('a[itemprop="url"]').eq(i);
+                    const LastA = $('a').eq(1);
 
-                likes.push({
-                    title: url.text(),
-                    url: `${Constants.SOUNDCLOUD_BASE_URL}${url.attr("href")}`,
-                    publishedAt: new Date($("time").eq(i).text()),
-                    genre: $('meta[itemprop="genre"]').eq(i).attr("content"),
-                    author: {
-                        name: LastA.text(),
-                        username: LastA.attr("href").replace("/", ""),
-                        profile: `${Constants.SOUNDCLOUD_BASE_URL}${LastA.attr("href")}`
-                    },
+                    likes.push({
+                        title: url.text(),
+                        url: `${Constants.SOUNDCLOUD_BASE_URL}${url.attr("href")}`,
+                        publishedAt: new Date($("time").eq(i).text()),
+                        genre: $('meta[itemprop="genre"]').eq(i).attr("content"),
+                        author: {
+                            name: LastA.text(),
+                            username: LastA.attr("href").replace("/", ""),
+                            profile: `${Constants.SOUNDCLOUD_BASE_URL}${LastA.attr("href")}`
+                        },
+                    });
                 });
-            });
 
-            const obj = {
-                urn: parseInt(URNSearch.groups.urn),
-                username: profile.split("/").pop(),
-                name: name,
-                verified: !html.includes(`,"username":"${name}","verified":false`),
-                createdAt: new Date(Util.last(html.split('"created_at":"')).split('","')[0]),
-                avatarURL: Util.last(html.split('"avatar_url":"')) ? Util.last(html.split('"avatar_url":"')).split('"')[0] : null,
-                profile: profile,
-                bannerURL: banner,
-                followers: parseInt(Util.last(html.split('"followers_count":')).split(',')[0]) || 0,
-                following: parseInt(Util.last(html.split('"followings_count":')).split(',')[0]) || 0,
-                likesCount: parseInt(Util.last(html.split('"likes_count":')).split(',')[0]) || 0,
-                tracksCount: parseInt(Util.last(html.split('"track_count":')).split(',')[0]) || 0,
-                tracks: songs,
-                likes: likes
-            };
+                const obj = {
+                    urn: parseInt(URNSearch.groups.urn),
+                    username: profile.split("/").pop(),
+                    name: name,
+                    verified: !html.includes(`,"username":"${name}","verified":false`),
+                    createdAt: new Date(Util.last(html.split('"created_at":"')).split('","')[0]),
+                    avatarURL: Util.last(html.split('"avatar_url":"')) ? Util.last(html.split('"avatar_url":"')).split('"')[0] : null,
+                    profile: profile,
+                    bannerURL: banner,
+                    followers: parseInt(Util.last(html.split('"followers_count":')).split(',')[0]) || 0,
+                    following: parseInt(Util.last(html.split('"followings_count":')).split(',')[0]) || 0,
+                    likesCount: parseInt(Util.last(html.split('"likes_count":')).split(',')[0]) || 0,
+                    tracksCount: parseInt(Util.last(html.split('"track_count":')).split(',')[0]) || 0,
+                    tracks: songs,
+                    likes: likes
+                };
 
-            resolve(obj);
+                return resolve(obj);
+            } catch (e) {
+                return reject(e);
+            }
         });
     }
 


### PR DESCRIPTION
Before add promise rejection handling, when I use wrong URL in getPlaylist, It cannot catch error because there wasn't promise rejection.
So I add the promise rejection handling.
```js
try {
    playlist = await client.getPlaylist(wrong_url);
} catch (e) {
    // cannot catch error by origin source
    // can catch error by PR source
}
```