### PR TITLE
Added check for progressive URL

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -237,9 +237,9 @@ class Client {
                             embed: null,
                             track: {
                                 hls: getMedia(m, "hls") ? getMedia(m, "hls").url : null,
-                                progressive: getMedia(m, "progressive").url
+                                progressive: getMedia(m, "progressive") ? getMedia(m, "progressive").url : null
                             },
-                            trackURL: getMedia(m, "progressive").url,
+                            trackURL: getMedia(m, "progressive") ? getMedia(m, "progressive").url : null,
                             comments: []
                         }))
                 };


### PR DESCRIPTION
added a check to set the progressive and track url to null if progressive attribute cannot be found in media

this PR is related to this error that I got while trying to download a playlist.

```
TypeError: Cannot read property 'url' of undefined at soundcloud-scraper/src/Client.js:242:65
```